### PR TITLE
Add openSUSE-release package to all openSUSE images

### DIFF
--- a/openSUSE_13.1/Makefile
+++ b/openSUSE_13.1/Makefile
@@ -13,4 +13,4 @@ clean ::
 	sudo rm -f $(BUILD_DIR).log
 
 import ::
-	docker import - opensuse:13.1 < $(OUTPUT_DIR)/suse-13.1-docker-guest-docker.x86_64-1.0.0.tbz
+	docker import - opensuse:13.1 < $(OUTPUT_DIR)/suse-13.1-docker-guest-docker.x86_64-1.0.0.tar.xz

--- a/openSUSE_13.1/config.xml
+++ b/openSUSE_13.1/config.xml
@@ -42,6 +42,7 @@
     <package name="coreutils"/>
     <package name="iputils"/>
     <package name="openSUSE-build-key"/>
+    <package name="openSUSE-release"/>
   </packages>
   <packages type="bootstrap">
     <package name="filesystem"/>

--- a/openSUSE_13.2/config.xml
+++ b/openSUSE_13.2/config.xml
@@ -42,6 +42,7 @@
     <package name="coreutils"/>
     <package name="iputils"/>
     <package name="openSUSE-build-key"/>
+    <package name="openSUSE-release"/>
   </packages>
   <packages type="bootstrap">
     <package name="filesystem"/>

--- a/openSUSE_Tumbleweed/config.xml
+++ b/openSUSE_Tumbleweed/config.xml
@@ -39,6 +39,7 @@
     <package name="coreutils"/>
     <package name="iputils"/>
     <package name="openSUSE-build-key"/>
+    <package name="openSUSE-release"/>
   </packages>
   <packages type="bootstrap">
     <package name="filesystem"/>


### PR DESCRIPTION
This pull request adds the `openSUSE-release` package to all openSUSE Docker images.

Without `openSUSE-release`, `/etc/os-release` is not available, which makes distribution detection quite hard for the official openSUSE images. So far all the distributions I checked (CentOS, Fedora, Debian, Ubuntu, Oracle Linux, Alpine) had `/etc/os-release` in their official Docker images, so it would be great if openSUSE could include `os-release` too.
