### PR TITLE
Introduce a production-ready image for Portus

### DIFF
--- a/derived_images/portus/README.md
+++ b/derived_images/portus/README.md
@@ -1,0 +1,137 @@
+The `docker` directory contains all the resources needed to create a
+production-ready Docker image for Portus.
+
+The master branch of this repository is going to include the files needed
+to build Portus from HEAD. Other branches are available to build Portus out of
+more stable branches. These branches are going to be named using the following
+scheme: `portus-<release>`.
+
+## Security
+
+SUSE's containers team cares about security, hence we made the following
+decisions:
+
+  * This image enforces the usage of HTTPS to access Portus.
+  * Portus is installed from an RPM package, this ensures the final image will
+    have only the runtime dependency; no build time dependency is ever installed.
+  * The default user for this image is the `wwwrun` one, which is created by the
+    Apache package.
+  * The root account is locked, that means it's not possible to switch user via
+    `su` or `sudo`.
+
+SUSE's containers team is constantly working to automate the release process
+of Portus and of this image to ensure it stays up-to-date and secure.
+
+When deploying this image make sure to add all the required keys and
+certificates at runtime instead of adding them to a Docker image.
+
+## Anatomy of the image
+
+The image is based on openSUSE 42.1 and installs Portus using the RPM package
+built by SUSE's containers team inside of the [Open Build Service](https://build.opensuse.org/project/subprojects/Virtualization:containers:Portus)
+top level project and subprojects (one subproject per portus branch).
+
+### Exposed ports
+
+This image will use [Phusion Passenger](https://www.phusionpassenger.com/) in
+conjunction with Apache to run Portus.
+
+The container will expose the following ports:
+
+  * 443: this is used to serve the website over HTTPS.
+  * 80: most of the requests sent to this unencrypted channel will be
+    automatically redirected to the HTTPS channel.
+    The redirection is made using Apache's [mod_rewrite](https://httpd.apache.org/docs/current/mod/mod_rewrite.html).
+
+The redirection from port 80 to port 443 applies to all the common requests sent
+to Portus. The only requests that are **not** redirected are the ones sent to
+the `v2/webhooks/events` endpoint. This is the endpoint used by the Docker
+Registry to send notifications to Portus.
+
+Sending Registry's notification to the HTTPS endpoint would require Portus'
+certificate to be added to the Docker container running the registry. This is
+not hard to be done, but involves some changes to the official Registry image
+maintained by Docker Inc (or some hacks like a custom entrypoint added via a volume).
+
+### The init script
+
+As mentioned before, this Docker image has a init script which takes care of the
+following actions:
+
+  1. Setup the database required by Portus
+  2. Import all the `.crt` located under `/certificates`
+  3. Start Apache
+
+The next sections will provide more details about these steps.
+
+### Volumes
+
+Portus' state is stored inside of a MariaDB database. This makes this Docker
+image stateless.
+
+### External database
+
+This image has a custom `init` script that takes care of configuring the external
+database.
+
+The script will keep trying to reach the database for 90 seconds. A 5 seconds
+pause is done after each failed attempt. The container will exit with an error
+message if the database is not reachable.
+
+The script will take care of the creation of the Portus database and its initial
+population via the usual Rails procedures.
+
+The database is automatically migrated whenever a new migration is introduced
+by the upstream project.
+
+### Secrets and certificates
+
+Portus requires both a SSL key and a certificate to serve its contents over
+HTTPS.
+These files must be located here:
+
+  * SSL certificate file: `/certificates/portus-ca.crt`
+  * SSL certificate key file: `/secrets/portus.key`
+
+The same key is also used to sign the JWT tokens issued to authenticate all the
+docker clients against the Registry.
+
+It's also required to add the certificate of the Registry when the latter one
+uses TLS to secure itself.
+The Registry certificate must be placed inside of `/certificates`, the `init`
+script of this image will automatically import it if it ends with the `.crt`
+extension.
+
+### Logging
+
+Both Portus' and Apache's messages are redirected to `stdout` and `stderr`. This
+makes it possible to handle the logs of this image in the usual ways.
+
+## Deployment
+
+It's possible to deploy this image using one of the existing orchestration
+solutions for Docker images.
+
+However we recommend the usage of [kubernetes](http://kubernetes.io/). We will
+soon release a reference implementation.
+
+### Environment variables
+
+The following environment variables must be defined to run the image:
+
+Security related settings:
+
+  * `PORTUS_SECRET_KEY_BASE`: you can generate it using `openssl rand -hex 64`
+  * `PORTUS_PORTUS_PASSWORD`: you can generate it using `openssl rand -hex 64`
+
+Database releated settings:
+
+  * `MARIADB_SERVICE_HOST`: the host running the MariaDB database.
+  * `MARIADB_USER`: the database user to be used.
+  * `MARIADB_PASSWORD`: the password of the database user.
+  * `MARIADB_DATABASE`: the name of the Portus database.
+
+Deployment related settings:
+
+  * `PORTUS_MACHINE_FQDN_VALUE`: this is the fully qualified domain name of your
+    Portus instance (eg: `portus.example.com`).

--- a/derived_images/portus/docker/Dockerfile
+++ b/derived_images/portus/docker/Dockerfile
@@ -1,0 +1,53 @@
+FROM opensuse/amd64:42.1
+MAINTAINER Flavio Castelli <fcastelli@suse.com>
+
+RUN zypper ar -f --no-gpgcheck obs://Virtualization:containers:Portus/openSUSE_Leap_42.1 portus-head && \
+    zypper ref && \
+    zypper -n in portus sudo && \
+    zypper clean -a
+
+# Add sudo rule that allows the wwwrun user to invoke update-ca-certificates
+ADD update-ca-certificates-sudoers /etc/sudoers.d/
+# Add sudo rule that allows the wwwrun user to invoke start_apache2; this
+# program is maintained by SUSE and will initialize Apache2 and ensure the httpd
+# daemon is run as wwwrun user.
+ADD start_apache2-sudoers /etc/sudoers.d/
+# Configure sudo to not wipe out all the existing env variables,
+# this would cause lots of troubles when starting Portus via our init
+# script
+RUN sed -i -e 's/Defaults env_reset/Defaults !env_reset/' /etc/sudoers
+
+# apache configuration
+RUN a2enmod passenger
+RUN a2enmod rewrite
+RUN a2enmod ssl
+RUN a2enflag SSL
+ADD apache.conf /etc/apache2/vhosts.d/portus.conf
+
+# Custom certificates must be placed inside of /certificates,
+RUN rm -rf /etc/pki/trust/anchors && \
+    ln -sf /certificates /etc/pki/trust/anchors
+
+# Portus will log everything to stdout and stderr by default,
+# however Apache will capture everything and send it to text file.
+# This would break commands like `docker logs` and `kubectl logs`.
+# That's why we use this trick.
+RUN ln -sf /dev/stdout /var/log/apache2/access_log
+RUN ln -sf /dev/stderr /var/log/apache2/error_log
+# The stable release of Portus is not logging to STDOUT by default when
+# used in production mode. We have to use this temporary workaround
+RUN ln -sf /dev/stdout /srv/Portus/log/production.log
+
+# portus configuration
+ADD database.yml secrets.yml /srv/Portus/config/
+
+ADD init /
+ADD check_db.rb /check_db.rb
+
+EXPOSE 80 443
+
+ENTRYPOINT ["/init"]
+
+# Disable password login for the root user
+RUN passwd --lock root
+USER wwwrun

--- a/derived_images/portus/docker/apache.conf
+++ b/derived_images/portus/docker/apache.conf
@@ -1,0 +1,55 @@
+# Ensure Rails error messages at bootstrap are not swallowed by Passenger
+PassengerLogLevel 4
+
+<VirtualHost *:80>
+
+  DocumentRoot /srv/Portus/public
+  <Directory /srv/Portus/public>
+    # Automatically rewrite all the request to the https end point
+    # except for the notifications sent from the registry to Portus
+    # These one can be transmitted over http so we don't have to add
+    # portus' certificate to the official registry image.
+    RewriteEngine On
+    RewriteRule ^(?!v2/webhooks/events) https://%{SERVER_NAME}/$1 [R,L]
+
+    # This relaxes Apache security settings.
+    AllowOverride all
+    # MultiViews must be turned off.
+    Options -MultiViews
+
+    # required by mod_rewrite
+    Options FollowSymLinks SymLinksIfOwnerMatch
+
+    Require all granted
+    SetEnv GEM_PATH /srv/Portus/vendor/bundle/ruby/2.1.0
+    SetEnv PASSENGER_COMPILE_NATIVE_SUPPORT_BINARY 0
+    SetEnv PASSENGER_DOWNLOAD_NATIVE_SUPPORT_BINARY 0
+    SetEnv PORTUS_CHECK_SSL_USAGE_ENABLED false
+    PassEnv MARIADB_SERVICE_HOST
+    PassEnv MARIADB_SERVICE_PORT
+    PassEnv PORTUS_MACHINE_FQDN
+    PassengerAppEnv production
+  </Directory>
+</VirtualHost>
+
+<VirtualHost *:443>
+  SSLEngine on
+  SSLCertificateFile /certificates/portus-ca.crt
+  SSLCertificateKeyFile /secrets/portus.key
+
+  DocumentRoot /srv/Portus/public
+  <Directory /srv/Portus/public>
+    # This relaxes Apache security settings.
+    AllowOverride all
+    # MultiViews must be turned off.
+    Options -MultiViews
+    Require all granted
+    SetEnv GEM_PATH /srv/Portus/vendor/bundle/ruby/2.1.0
+    SetEnv PASSENGER_COMPILE_NATIVE_SUPPORT_BINARY 0
+    SetEnv PASSENGER_DOWNLOAD_NATIVE_SUPPORT_BINARY 0
+    PassEnv MARIADB_SERVICE_HOST
+    PassEnv MARIADB_SERVICE_PORT
+    PassEnv PORTUS_MACHINE_FQDN
+    PassengerAppEnv production
+  </Directory>
+</VirtualHost>

--- a/derived_images/portus/docker/check_db.rb
+++ b/derived_images/portus/docker/check_db.rb
@@ -1,0 +1,22 @@
+# This is a rails runner that will print the status of Portus' database
+# Possible outcomes:
+#
+#   * `DB_READY`: the database has been created and initialized
+#   * `DB_EMPTY`: the database has been created but has not been initialized
+#   * `DB_MISSING`: the database has not been created
+#   * `DB_DOWN`: cannot connect to the database
+
+def database_exists?
+  ActiveRecord::Base.connection
+  if ActiveRecord::Base.connection.table_exists? 'schema_migrations'
+    puts "DB_READY"
+  else
+    puts "DB_EMPTY"
+  end
+rescue ActiveRecord::NoDatabaseError
+  puts "DB_MISSING"
+rescue Mysql2::Error
+  puts "DB_DOWN"
+end
+
+database_exists?

--- a/derived_images/portus/docker/database.yml
+++ b/derived_images/portus/docker/database.yml
@@ -1,0 +1,7 @@
+production:
+  adapter: mysql2
+  encoding: utf8
+  host: <%= ENV['MARIADB_SERVICE_HOST'] %>
+  username: <%= ENV['MARIADB_USER'] %>
+  password: <%= ENV['MARIADB_PASSWORD'] %>
+  database: <%= ENV['MARIADB_DATABASE'] %>

--- a/derived_images/portus/docker/init
+++ b/derived_images/portus/docker/init
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# This script will ensure Portus' database is ready to be used. It will keep
+# waiting for the db to be usable, but the script will exit with an error
+# after a certain amount of failed attempts.
+#
+# The script will automatically import all the SSL certificates from
+# `/certificates` into the final system. This is needed to talk with the
+# registry API when this one is protected by TLS.
+#
+# Finally the script will start apache running Portus via mod_rails.
+
+set -e
+
+setup_database() {
+  set +e
+
+  TIMEOUT=90
+  COUNT=0
+  RETRY=1
+
+  export SKIP_MIGRATION=1
+
+  while [ $RETRY -ne 0 ]; do
+    case $(SKIP_MIGRATION=1 portusctl exec rails r /check_db.rb | grep DB) in
+      "DB_DOWN")
+        if [ "$COUNT" -ge "$TIMEOUT" ]; then
+          printf " [FAIL]\n"
+          echo "Timeout reached, exiting with error"
+          exit 1
+        fi
+        echo "Waiting for mariadb to be ready in 5 seconds"
+        sleep 5
+        COUNT=$((COUNT+5))
+        ;;
+      "DB_EMPTY"|"DB_MISSING")
+        # create db, apply schema and seed
+        echo "Initializing database"
+        SKIP_MIGRATION=1 portusctl rake db:setup
+        if [ $? -ne 0 ]; then
+            echo "Error at setup time"
+            exit 1
+        fi
+        ;;
+      "DB_READY")
+        echo "Database ready"
+        break
+        ;;
+    esac
+  done
+  set -e
+}
+
+setup_database
+
+# ensure additional certificates (like the one of the docker registry)
+# are known
+sudo update-ca-certificates
+
+exec env sudo /usr/sbin/start_apache2 -DFOREGROUND -k start

--- a/derived_images/portus/docker/secrets.yml
+++ b/derived_images/portus/docker/secrets.yml
@@ -1,0 +1,4 @@
+production:
+  encryption_private_key_path: /secrets/portus.key
+  secret_key_base: <%= ENV["PORTUS_SECRET_KEY_BASE"] %>
+  portus_password:  <%= ENV["PORTUS_PORTUS_PASSWORD"] %>

--- a/derived_images/portus/docker/start_apache2-sudoers
+++ b/derived_images/portus/docker/start_apache2-sudoers
@@ -1,0 +1,1 @@
+wwwrun ALL = NOPASSWD: /usr/sbin/start_apache2

--- a/derived_images/portus/docker/update-ca-certificates-sudoers
+++ b/derived_images/portus/docker/update-ca-certificates-sudoers
@@ -1,0 +1,1 @@
+wwwrun ALL = NOPASSWD: /usr/sbin/update-ca-certificates


### PR DESCRIPTION
This commit introduces the Dockerfile and all the resources needed to build a production-ready image for Portus.

I'll add a kubernetes reference deployment under a new directory.

Once this PR is merged I'll create other branches with small changes to build the image out of the `2.0` and `2.0-git` packages.
