### PR TITLE
Use obsrepositories for the installation sources

### DIFF
--- a/openSUSE-42.1/config.kiwi
+++ b/openSUSE-42.1/config.kiwi
@@ -26,11 +26,8 @@
   <users group="root">
     <user password="linux" pwdformat="plain" home="/root" name="root"/>
   </users>
-  <repository type="rpm-md">
-    <source path="obs://openSUSE:Leap:42.1:Update/standard"/>
-  </repository>
-  <repository type="rpm-md">
-    <source path="obs://openSUSE:Leap:42.1/standard"/>
+  <repository>
+      <source path="obsrepositories:/"/>
   </repository>
   <packages type="image">
     <package name="ca-certificates"/>


### PR DESCRIPTION
This way the kiwi build environment and the install source don't
get out of sync, and you can easily add forks that don't need local
patches for e.g. building openSUSE ports for aarch64 and ppc64le
