### PR TITLE
remove root password from images

### DIFF
--- a/openSUSE-13.2/config.kiwi
+++ b/openSUSE-13.2/config.kiwi
@@ -24,7 +24,7 @@
     <timezone>US/Eastern</timezone>
   </preferences>
   <users group="root">
-    <user password="linux" pwdformat="plain" home="/root" name="root"/>
+    <user home="/root" name="root"/>
   </users>
   <repository type="rpm-md">
     <source path="obs://openSUSE:13.2:Update/standard"/>

--- a/openSUSE-42.1/config.kiwi
+++ b/openSUSE-42.1/config.kiwi
@@ -24,7 +24,7 @@
     <timezone>US/Eastern</timezone>
   </preferences>
   <users group="root">
-    <user password="linux" pwdformat="plain" home="/root" name="root"/>
+    <user home="/root" name="root"/>
   </users>
   <repository>
       <source path="obsrepositories:/"/>

--- a/openSUSE-42.2/config.kiwi
+++ b/openSUSE-42.2/config.kiwi
@@ -24,7 +24,7 @@
     <timezone>US/Eastern</timezone>
   </preferences>
   <users group="root">
-    <user password="linux" pwdformat="plain" home="/root" name="root"/>
+    <user home="/root" name="root"/>
   </users>
   <repository>
       <source path="obsrepositories:/"/>

--- a/openSUSE-Tumbleweed/config.kiwi
+++ b/openSUSE-Tumbleweed/config.kiwi
@@ -24,7 +24,7 @@
     <timezone>US/Eastern</timezone>
   </preferences>
   <users group="root">
-    <user password="linux" pwdformat="plain" home="/root" name="root"/>
+    <user home="/root" name="root"/>
   </users>
   <repository>
     <source path="obsrepositories:/"/>


### PR DESCRIPTION
Currently our KIWI images set a fixed root password. We should not do this.
DISCLAIMER: @cyphar and I weren't sure whether this commit will really fix the issue. There is the possibility that KIWI somehow generates a random password somewhere independent of this configuration file. In that case we _might_ have to patch KIWI if we really do not want any root password at all. Another thing is that KIWI by itself does not create a root user if not instructed to do so. Hopefully removing the password will still leave the creation of a root user intact. If not we must revert.

Signed-off-by: Christian Brauner cbrauner@suse.com
