### PR TITLE
Use obsrepos for 13.2

### DIFF
--- a/openSUSE-13.2/config.kiwi
+++ b/openSUSE-13.2/config.kiwi
@@ -26,11 +26,8 @@
   <users group="root">
     <user home="/root" name="root"/>
   </users>
-  <repository type="rpm-md">
-    <source path="obs://openSUSE:13.2:Update/standard"/>
-  </repository>
-  <repository type="rpm-md">
-    <source path="obs://openSUSE:13.2/standard"/>
+  <repository>
+    <source path="obsrepositories:/"/>
   </repository>
   <packages type="image">
     <package name="ca-certificates"/>


### PR DESCRIPTION
Just use the OBS repositiories the same way we are already doing for the
other base images.

Signed-off-by: Thomas Boerger tboerger@suse.de
