### PR TITLE
remove EDT timezone

### DIFF
--- a/openSUSE-13.2/config.kiwi
+++ b/openSUSE-13.2/config.kiwi
@@ -21,7 +21,6 @@
     <locale>en_US</locale>
     <keytable>us.map.gz</keytable>
     <hwclock>utc</hwclock>
-    <timezone>US/Eastern</timezone>
   </preferences>
   <users group="root">
     <user home="/root" name="root"/>

--- a/openSUSE-42.1/config.kiwi
+++ b/openSUSE-42.1/config.kiwi
@@ -21,7 +21,6 @@
     <locale>en_US</locale>
     <keytable>us.map.gz</keytable>
     <hwclock>utc</hwclock>
-    <timezone>US/Eastern</timezone>
   </preferences>
   <users group="root">
     <user home="/root" name="root"/>

--- a/openSUSE-42.2/config.kiwi
+++ b/openSUSE-42.2/config.kiwi
@@ -21,7 +21,6 @@
     <locale>en_US</locale>
     <keytable>us.map.gz</keytable>
     <hwclock>utc</hwclock>
-    <timezone>US/Eastern</timezone>
   </preferences>
   <users group="root">
     <user home="/root" name="root"/>

--- a/openSUSE-Tumbleweed/config.kiwi
+++ b/openSUSE-Tumbleweed/config.kiwi
@@ -21,7 +21,6 @@
     <locale>en_US</locale>
     <keytable>us.map.gz</keytable>
     <hwclock>utc</hwclock>
-    <timezone>US/Eastern</timezone>
   </preferences>
   <users group="root">
     <user home="/root" name="root"/>


### PR DESCRIPTION
This was only a problem for openSUSE-Tumbleweed. But let's remove it from the others as well. Building the images locally with osc build confirmed that the timezones were set to UTC for Tumbleweed as well after this patch.

Signed-off-by: Christian Brauner cbrauner@suse.com
