### PR TITLE
add python image

### DIFF
--- a/derived_images/python/Dockerfile
+++ b/derived_images/python/Dockerfile
@@ -1,0 +1,5 @@
+FROM opensuse:42.1
+MAINTAINER SUSE Manager Team <galaxy-bugs@suse.de>
+
+# Only python is added
+RUN zypper in -y python

--- a/derived_images/python/README.md
+++ b/derived_images/python/README.md
@@ -1,0 +1,2 @@
+This image is just a python enabled image for Leap, which allows it to be used
+as a base to build Docker images using Salt.


### PR DESCRIPTION
This python image is to allow building Docker containers using Salt (and to try to change the default base image to be a SUSE based one)
