### PR TITLE
Allow to set Portus encryption key with PORTUS_KEY_PATH envvar

### DIFF
--- a/derived_images/portus/docker/Dockerfile
+++ b/derived_images/portus/docker/Dockerfile
@@ -51,6 +51,8 @@ COPY database.yml secrets.yml /srv/Portus/config/
 COPY init /
 COPY check_db.rb /check_db.rb
 
+ENV PORTUS_KEY_PATH /secrets/portus.key
+
 EXPOSE 80 443
 
 ENTRYPOINT ["/init"]

--- a/derived_images/portus/docker/secrets.yml
+++ b/derived_images/portus/docker/secrets.yml
@@ -1,4 +1,4 @@
 production:
-  encryption_private_key_path: /secrets/portus.key
+  encryption_private_key_path: <%= ENV["PORTUS_KEY_PATH"] %>
   secret_key_base: <%= ENV["PORTUS_SECRET_KEY_BASE"] %>
   portus_password:  <%= ENV["PORTUS_PORTUS_PASSWORD"] %>


### PR DESCRIPTION
This PR is made in order to be able to set the Portus encryption key path through the environment variable PORTUS_KEY_PATH in the official Portus Docker image.

This allows the docker image behaviour to be consistent with the official Portus documentation: 

_The rootcertbundle should point to the same location as the encryption_private_key_path configurable value as defined also in the config/secrets.yml file. This can be also tweaked with the PORTUS_KEY_PATH environment variable._

http://port.us.org/docs/How-to-setup-secure-registry.html