### PR TITLE
Install python-MySQL-python package by default

### DIFF
--- a/derived_images/salt/salt-master/Dockerfile
+++ b/derived_images/salt/salt-master/Dockerfile
@@ -2,7 +2,7 @@ FROM opensuse:leap
 MAINTAINER SUSE Containers Team <containers@suse.com>
 
 RUN zypper ref && \
-    zypper -n in salt-master && \
+    zypper -n in salt-master python-MySQL-python && \
     zypper clean -a
 
 RUN useradd -MNrs /bin/false saltapi


### PR DESCRIPTION
The salt-master can interact out-of-the box with a MariaDB/MySQL
instance by installing the python-MySQL-python package.