### PR TITLE
Enable Crono support for Portus

### DIFF
--- a/derived_images/portus/docker/Dockerfile
+++ b/derived_images/portus/docker/Dockerfile
@@ -10,7 +10,7 @@ COPY rpm-import-repo-key /usr/sbin/
 RUN rpm-import-repo-key 55A0B34D49501BB7CA474F5AA193FBB572174FC2 && \
     zypper ar -f obs://Virtualization:containers:Portus/openSUSE_Leap_42.1 portus-head && \
     zypper ref && \
-    zypper -n in portus sudo ruby2.1-rubygem-bundler && \
+    zypper -n in portus sudo rubygem\(bundler\) && \
     zypper clean -a
 
 # Add sudo rule that allows the wwwrun user to invoke update-ca-certificates

--- a/derived_images/portus/docker/Dockerfile
+++ b/derived_images/portus/docker/Dockerfile
@@ -10,7 +10,7 @@ COPY rpm-import-repo-key /usr/sbin/
 RUN rpm-import-repo-key 55A0B34D49501BB7CA474F5AA193FBB572174FC2 && \
     zypper ar -f obs://Virtualization:containers:Portus/openSUSE_Leap_42.1 portus-head && \
     zypper ref && \
-    zypper -n in portus sudo && \
+    zypper -n in portus sudo ruby2.1-rubygem-bundler && \
     zypper clean -a
 
 # Add sudo rule that allows the wwwrun user to invoke update-ca-certificates
@@ -54,6 +54,7 @@ COPY check_db.rb /check_db.rb
 EXPOSE 80 443
 
 ENTRYPOINT ["/init"]
+CMD ["portus"]
 
 # Disable password login for the root user
 RUN passwd --lock root

--- a/derived_images/portus/docker/init
+++ b/derived_images/portus/docker/init
@@ -55,15 +55,20 @@ setup_database() {
 # are known
 sudo update-ca-certificates
 
-if [ "$1" == 'portus' ]; then
+case "$1" in
+
+    'portus') 
 	setup_database
 	exec env sudo /usr/sbin/start_apache2 -DFOREGROUND -k start
-fi
+	;;
 
-if [ "$1" == 'crono' ]; then
+    'crono')
 	cd /srv/Portus
-	RAILS_ENV=production exec bin/crono
-fi
+        RAILS_ENV=production exec bin/crono
+	;;
 
-exec "$@"
+    *)
+	exec "$@"
+	;;
 
+esac

--- a/derived_images/portus/docker/init
+++ b/derived_images/portus/docker/init
@@ -51,10 +51,19 @@ setup_database() {
   set -e
 }
 
-setup_database
-
 # ensure additional certificates (like the one of the docker registry)
 # are known
 sudo update-ca-certificates
 
-exec env sudo /usr/sbin/start_apache2 -DFOREGROUND -k start
+if [ "$1" == 'portus' ]; then
+	setup_database
+	exec env sudo /usr/sbin/start_apache2 -DFOREGROUND -k start
+fi
+
+if [ "$1" == 'crono' ]; then
+	cd /srv/Portus
+	RAILS_ENV=production exec bin/crono
+fi
+
+exec "$@"
+


### PR DESCRIPTION
This PR modifies the `Dockerfile` and `init` scripts to either run Portus itself (which is the default) or the crono agent.

To run Portus, use the image as documented, e.g.

```
$ docker run --restart=always --name portus \
   --link mariadb:mariadb \
  -e MARIADB_SERVICE_HOST=mariadb \
  -e MARIADB_USER=portus \
  -e MARIADB_PASSWORD=portus \
  -e MARIADB_DATABASE=portus \   
opensuse/portus:head
```

To run Crono, add the command `crono` to the `docker run` command:

```
$ docker run --restart=always --name portus \
   --link mariadb:mariadb \
  -e MARIADB_SERVICE_HOST=mariadb \
  -e MARIADB_USER=portus \
  -e MARIADB_PASSWORD=portus \
  -e MARIADB_DATABASE=portus \
   opensuse/portus:head crono
```

It also allows you to pass any other parameter, e.g. `bash` to exec that instead.

Signed-off-by: Avi Miller <avi.miller@gmail.com>