### PR TITLE
Add python-M2Crypto dependency.

### DIFF
--- a/derived_images/salt/salt-minion/Dockerfile
+++ b/derived_images/salt/salt-minion/Dockerfile
@@ -2,7 +2,7 @@ FROM opensuse:leap
 MAINTAINER SUSE Containers Team <containers@suse.com>
 
 RUN zypper ref && \
-    zypper -n in salt-minion && \
+    zypper -n in salt-minion python-M2Crypto && \
     zypper clean -a
 
 ADD salt-minion.sh /


### PR DESCRIPTION
This is required for certain usages of upstream salt modules (x509
is a good example). We are trying to keep this image as generic as
possible, but it's good to include dependencies that upstream
modules might need so it's straightforward to use this image as a
base for your own deployments.