### PR TITLE
Include krb5 package

### DIFF
--- a/openSUSE-42.1/config.kiwi
+++ b/openSUSE-42.1/config.kiwi
@@ -36,6 +36,10 @@
     <package name="openSUSE-build-key"/>
     <package name="openSUSE-release"/>
     <package name="openSUSE-release-mini"/>
+    <!-- 
+        Needed to avoid the inclusion of krb5-mini by the OBS solver
+    -->
+    <package name="krb5"/> 
   </packages>
   <packages type="bootstrap">
     <package name="acl"/>

--- a/openSUSE-42.2/config.kiwi
+++ b/openSUSE-42.2/config.kiwi
@@ -36,6 +36,10 @@
     <package name="openSUSE-build-key"/>
     <package name="openSUSE-release"/>
     <package name="openSUSE-release-mini"/>
+    <!--
+        Needed to avoid the inclusion of krb5-mini by the OBS solver
+    -->
+    <package name="krb5"/>
   </packages>
   <packages type="bootstrap">
     <package name="acl"/>

--- a/openSUSE-42.3/config.kiwi
+++ b/openSUSE-42.3/config.kiwi
@@ -36,6 +36,10 @@
     <package name="openSUSE-build-key"/>
     <package name="openSUSE-release"/>
     <package name="openSUSE-release-mini"/>
+    <!-- 
+        Needed to avoid the inclusion of krb5-mini by the OBS solver
+    -->
+    <package name="krb5"/>
   </packages>
   <packages type="bootstrap">
     <package name="acl"/>

--- a/openSUSE-Tumbleweed/config.kiwi
+++ b/openSUSE-Tumbleweed/config.kiwi
@@ -36,6 +36,10 @@
     <package name="openSUSE-build-key"/>
     <package name="openSUSE-release"/>
     <package name="openSUSE-release-mini"/>
+    <!-- 
+        Needed to avoid the inclusion of krb5-mini by the OBS solver
+    -->
+    <package name="krb5"/>
   </packages>
   <packages type="bootstrap">
     <package name="ncurses-utils"/>


### PR DESCRIPTION
Add krb5 package to avoid the inclusion of krb5-mini by the OBS
solver. Krb5-mini causes some dependencies conflics with many
packages that expects krb5 and not krb5-mini.

Fixes #54