### PR TITLE
portus: use openSUSE Leap 42.3 as the base image

### DIFF
--- a/derived_images/portus/Dockerfile
+++ b/derived_images/portus/Dockerfile
@@ -1,4 +1,4 @@
-FROM opensuse/amd64:42.2
+FROM opensuse/amd64:42.3
 MAINTAINER SUSE Containers Team <containers@suse.com>
 
 # Install some helper scripts:


### PR DESCRIPTION
With this version, this Docker image works as always but it's 25MB
thinner than with 42.2.

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>