### PR TITLE
portus: force ruby-common to be installed from portus repo, otherwise…

### DIFF
--- a/derived_images/portus/Dockerfile
+++ b/derived_images/portus/Dockerfile
@@ -14,7 +14,7 @@ RUN chmod +x /rpm-import-repo-key /init && \
     /rpm-import-repo-key 55A0B34D49501BB7CA474F5AA193FBB572174FC2 && \
     zypper ar -f obs://Virtualization:containers:Portus/openSUSE_Leap_42.3 portus && \
     zypper ref && \
-    zypper -n in portus && \
+    zypper -n in --from portus ruby-common portus && \
     zypper -n rm kbd-legacy && \
     zypper clean -a && \
     rm /rpm-import-repo-key && \


### PR DESCRIPTION
… it installs ruby2.1