### PR TITLE
The background process has been introduced into portus, and it is way

### DIFF
--- a/derived_images/portus/Dockerfile
+++ b/derived_images/portus/Dockerfile
@@ -14,7 +14,7 @@ RUN chmod +x /rpm-import-repo-key /init && \
     /rpm-import-repo-key 55A0B34D49501BB7CA474F5AA193FBB572174FC2 && \
     zypper ar -f obs://Virtualization:containers:Portus/openSUSE_Leap_42.3 portus && \
     zypper ref && \
-    zypper -n in portus && \
+    zypper -n in --from portus ruby-common portus && \
     zypper -n rm kbd-legacy && \
     zypper clean -a && \
     rm /rpm-import-repo-key && \

--- a/derived_images/portus/README.md
+++ b/derived_images/portus/README.md
@@ -150,6 +150,10 @@ Executing other commands:
   * `PORTUS_INIT_COMMAND`: you can set this environment variable with the
     command that you'd like to run. For example, if you want to run crono, you
     can set it to "bin/crono".
+  * `PORTUS_BACKGROUND`: you can set this environment to true in order to
+    indicate that the process to be executed is the rails runner
+    `bin/background.rb` (that is, the background process). This is a shortcut
+    for `PORTUS_INIT_COMMAND=rails r /srv/Portus/bin/background.rb`.
 
 You can also pass further environment variables to configure Portus as
 described [here](http://port.us.org/docs/Configuring-Portus.html#override-specific-configuration-options).

--- a/derived_images/portus/init
+++ b/derived_images/portus/init
@@ -58,11 +58,13 @@ update-ca-certificates
 export PORTUS_PUMA_HOST="0.0.0.0:3000"
 export RACK_ENV="production"
 export RAILS_ENV="production"
-export GEM_PATH="/srv/Portus/vendor/bundle/ruby/2.1.0"
+export GEM_PATH="/srv/Portus/vendor/bundle/ruby/2.4.0"
 
 # Go to the Portus directory and execute the proper command.
 cd /srv/Portus
-if [ -z "$PORTUS_INIT_COMMAND" ]; then
+if [ ! -z "$PORTUS_BACKGROUND" ]; then
+    portusctl exec rails r /srv/Portus/bin/background.rb
+elif [ -z "$PORTUS_INIT_COMMAND" ]; then
     setup_database
     portusctl exec "pumactl -F /srv/Portus/config/puma.rb start"
 else


### PR DESCRIPTION
easier to simply have an environment variable that toggles this
functionality.

The `PORTUS_INIT_COMMAND` environment variable is left untouched for
debugging purposes.

Moreover, this commit also updates the GEM_PATH environment so it uses
ruby 2.4 and not 2.1.

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>