### PR TITLE
Update environment variable names to PORTUS_DB_xxxx

### DIFF
--- a/derived_images/portus/README.md
+++ b/derived_images/portus/README.md
@@ -125,11 +125,13 @@ Security related settings:
     SSL altogether.
 
 Database releated settings:
+Se [configuring the database](http://port.us.org/docs/database.html)
 
-  * `PORTUS_PRODUCTION_HOST`: the host running the MariaDB database.
-  * `PORTUS_PRODUCTION_USERNAME`: the database user to be used.
-  * `PORTUS_PRODUCTION_PASSWORD`: the password of the database user.
-  * `PORTUS_PRODUCTION_DATABASE`: the name of the Portus database.
+  * `PORTUS_DB_ADAPTER`: databasetype. Legal values are postgresql or mysql2. Default is mysql2
+  * `PORTUS_DB_HOST`: the host running the MariaDB (or Postgres) database.
+  * `PORTUS_DB_USERNAME`: the database user to be used.
+  * `PORTUS_DB_PASSWORD`: the password of the database user.
+  * `PORTUS_DB_DATABASE`: the name of the Portus database.
 
 Deployment related settings:
 

--- a/derived_images/portus/README.md
+++ b/derived_images/portus/README.md
@@ -124,16 +124,16 @@ Security related settings:
   * `PORTUS_CHECK_SSL_USAGE_ENABLED`: Set this to `false` if you want to disable
     SSL altogether.
 
-Database releated settings (se [configuring the database](http://port.us.org/docs/database.html) for details):
+Database releated settings (see [configuring the database](http://port.us.org/docs/database.html) for details):
 
-  * `PORTUS_DB_ADAPTER`: databasetype. Legal values are postgresql or mysql2. Default is mysql2
+  * `PORTUS_DB_ADAPTER`: database type. Supported values are `postgresql` and `mysql2`. Default is `mysql2`.
   * `PORTUS_DB_HOST`: the host running the MariaDB (or Postgres) database.
   * `PORTUS_DB_USERNAME`: the database user to be used.
   * `PORTUS_DB_PASSWORD`: the password of the database user.
   * `PORTUS_DB_DATABASE`: the name of the Portus database.
-  * `PORTUS_DB_PORT`: alternative database port number
-  * `PORTUS_DB_POOL`: the number of pool connections
-  * `PORTUS_DB_TIMEOUT`: timeoutvalue for requests
+  * `PORTUS_DB_PORT`: alternative database port number.
+  * `PORTUS_DB_POOL`: the number of pool connections.
+  * `PORTUS_DB_TIMEOUT`: timeout value for requests.
 
 Deployment related settings:
 

--- a/derived_images/portus/README.md
+++ b/derived_images/portus/README.md
@@ -124,14 +124,16 @@ Security related settings:
   * `PORTUS_CHECK_SSL_USAGE_ENABLED`: Set this to `false` if you want to disable
     SSL altogether.
 
-Database releated settings:
-Se [configuring the database](http://port.us.org/docs/database.html)
+Database releated settings (se [configuring the database](http://port.us.org/docs/database.html) for details):
 
   * `PORTUS_DB_ADAPTER`: databasetype. Legal values are postgresql or mysql2. Default is mysql2
   * `PORTUS_DB_HOST`: the host running the MariaDB (or Postgres) database.
   * `PORTUS_DB_USERNAME`: the database user to be used.
   * `PORTUS_DB_PASSWORD`: the password of the database user.
   * `PORTUS_DB_DATABASE`: the name of the Portus database.
+  * `PORTUS_DB_PORT`: alternative database port number
+  * `PORTUS_DB_POOL`: the number of pool connections
+  * `PORTUS_DB_TIMEOUT`: timeoutvalue for requests
 
 Deployment related settings:
 


### PR DESCRIPTION
Congratulations with the v2.3 release
And thank you for Portus. We love it!

Here are some minor changes in the environment names on the documentation page