### PR TITLE
fix ruby 2.5 docker image

### DIFF
--- a/derived_images/ruby/Dockerfile-2.5
+++ b/derived_images/ruby/Dockerfile-2.5
@@ -8,6 +8,7 @@ RUN chmod +x /rpm-import-repo-key && \
     zypper ar -f obs://devel:languages:ruby/openSUSE_Leap_42.3 ruby && \
     zypper -n in --no-recommends ruby2.5 ruby2.5-rubygem-gem2rpm && \
     zypper clean -a && \
-    rm /rpm-import-repo-key
+    rm /rpm-import-repo-key && \
+    update-alternatives --install /usr/bin/ruby ruby /usr/bin/ruby.ruby2.5 3 && \
+    update-alternatives --install /usr/bin/gem gem /usr/bin/gem.ruby2.5 3
 
-RUN update-alternatives --install /usr/bin/ruby ruby /usr/bin/ruby.ruby2.5 3

--- a/derived_images/ruby/Dockerfile-2.5
+++ b/derived_images/ruby/Dockerfile-2.5
@@ -6,6 +6,8 @@ COPY rpm-import-repo-key /
 RUN chmod +x /rpm-import-repo-key && \
     sync && /rpm-import-repo-key A9EA39C49B6B9E93B6863F849AF0C9A20E9AF123 && \
     zypper ar -f obs://devel:languages:ruby/openSUSE_Leap_42.3 ruby && \
-    zypper -n in --no-recommends ruby2.5 && \
+    zypper -n in --no-recommends ruby2.5 ruby2.5-rubygem-gem2rpm && \
     zypper clean -a && \
     rm /rpm-import-repo-key
+
+RUN update-alternatives --install /usr/bin/ruby ruby /usr/bin/ruby.ruby2.5 3


### PR DESCRIPTION
force the installation of ruby2.5-rubygem-gem2rpm. Otherwise we get
ruby2.1-rubygem-gem2rpm and that pulls in ruby2.1

Signed-off-by: Jordi Massaguer Pla <jmassaguerpla@suse.de>