### PR TITLE
portus: don't use the rake shortcut

### DIFF
--- a/derived_images/portus/init
+++ b/derived_images/portus/init
@@ -34,7 +34,7 @@ setup_database() {
       "DB_EMPTY"|"DB_MISSING")
         # create db, apply schema and seed
         echo "Initializing database"
-        portusctl rake db:setup
+        portusctl exec rake db:setup
         if [ $? -ne 0 ]; then
             echo "Error at setup time"
             exit 1


### PR DESCRIPTION
Use the `exec` command instead. This command will work with both the
deprecated and the new portusctl. The difference is that the `rake`
command will not be supported by the new one.

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>