### PR TITLE
portus: set the CCONFIG_PREFIX variable

### DIFF
--- a/derived_images/portus/init
+++ b/derived_images/portus/init
@@ -57,6 +57,7 @@ export PORTUS_PUMA_HOST="0.0.0.0:3000"
 export RACK_ENV="production"
 export RAILS_ENV="production"
 export GEM_PATH="/srv/Portus/vendor/bundle/ruby/2.5.0"
+export CCONFIG_PREFIX="PORTUS"
 
 # Go to the Portus directory and execute the proper command.
 cd /srv/Portus


### PR DESCRIPTION
It shouldn't be needed, but it's been buggy in the past, so it's better
to be safe than sorry.

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>