### PR TITLE
Cleanup kiwi description file and config.sh

### DIFF
--- a/openSUSE-Tumbleweed/config.kiwi
+++ b/openSUSE-Tumbleweed/config.kiwi
@@ -29,6 +29,7 @@
     <package name="openSUSE-build-key"/>
     <package name="krb5"/>
     <package name="netcfg"/>
+    <package name="kubic-locale-archive"/>
   </packages>
   <packages type="bootstrap">
     <package name="aaa_base"/>

--- a/openSUSE-Tumbleweed/config.kiwi
+++ b/openSUSE-Tumbleweed/config.kiwi
@@ -13,18 +13,11 @@
         tag="tumbleweed"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;"/>
     </type>
-    <version>1.0.3</version>
+    <version>1.0.4</version>
     <packagemanager>zypper</packagemanager>
     <rpm-check-signatures>false</rpm-check-signatures>
-    <rpm-force>true</rpm-force>
     <rpm-excludedocs>true</rpm-excludedocs>
-    <locale>en_US</locale>
-    <keytable>us.map.gz</keytable>
-    <hwclock>utc</hwclock>
   </preferences>
-  <users>
-    <user home="/root" name="root" groups="root"/>
-  </users>
   <repository>
     <source path="obsrepositories:/"/>
   </repository>
@@ -34,38 +27,15 @@
     <package name="coreutils"/>
     <package name="iputils"/>
     <package name="openSUSE-build-key"/>
-    <package name="openSUSE-release"/>
-    <package name="openSUSE-release-mini"/>
-    <!-- 
-        Needed to avoid the inclusion of krb5-mini by the OBS solver
-    -->
     <package name="krb5"/>
+    <package name="netcfg"/>
   </packages>
   <packages type="bootstrap">
-    <package name="ncurses-utils"/>
-    <package name="acl"/>
-    <package name="dracut"/>
-    <package name="elfutils"/>
-    <package name="filesystem"/>
-    <package name="glibc-locale"/>
-    <package name="pkg-config"/>
-    <package name="sg3_utils"/>
-  </packages>
-  <packages type="delete">
     <package name="aaa_base"/>
-    <package name="dbus-1"/>
-    <package name="dracut"/>
-    <package name="fipscheck"/>
-    <package name="glibc-locale"/>
-    <package name="kbd"/>
-    <package name="kmod"/>
-    <package name="ncurses-utils"/>
-    <package name="pinentry"/>
-    <package name="pkg-config"/>
-    <package name="sg3_utils"/>
-    <package name="systemd"/>
-    <package name="systemd-presets-branding-openSUSE"/>
-    <package name="systemd-sysvinit"/>
-    <package name="udev"/>
+    <package name="cracklib-dict-small"/>
+    <package name="filesystem"/>
+    <package name="openSUSE-release"/>
+    <package name="openSUSE-release-mini"/>
+    <package name="shadow"/>
   </packages>
 </image>

--- a/openSUSE-Tumbleweed/config.sh
+++ b/openSUSE-Tumbleweed/config.sh
@@ -32,19 +32,9 @@ echo "Configure image: [$kiwi_iname]..."
 suseSetupProduct
 
 #======================================
-# SuSEconfig
-#--------------------------------------
-suseConfig
-
-#======================================
 # Import repositories' keys
 #--------------------------------------
 suseImportBuildKey
-
-#======================================
-# Umount kernel filesystems
-#--------------------------------------
-baseCleanMount
 
 #======================================
 # Add repositories
@@ -80,6 +70,11 @@ esac
 # Disable recommends
 #--------------------------------------
 sed -i 's/.*solver.onlyRequires.*/solver.onlyRequires = true/g' /etc/zypp/zypp.conf
+
+#======================================
+# Exclude docs intallation
+#--------------------------------------
+sed -i 's/.*rpm.install.excludedocs.*/# rpm.install.excludedocs = yes/g' /etc/zypp/zypp.conf
 
 #======================================
 # Remove locale files


### PR DESCRIPTION
This commit removes some unneeded stuff from the description file and
from the config.sh script.

config.sh:
  - suseConfig is a deprecated method
  - there is no need to unmount any filesystem, kiwi process already does it
  - configure exclude docs flag in zypper

config.kiwi:
  - remove user definition
  - remove the delete packages section as it doesn't make a difference
  - remove locales settings, they are set by systemd which is not present