### PR TITLE
Simplified setup, allowing background together with puma in same container.

### DIFF
--- a/derived_images/portus/README.md
+++ b/derived_images/portus/README.md
@@ -158,6 +158,8 @@ Executing other commands:
     indicate that the process to be executed is the rails runner
     `bin/background.rb` (that is, the background process). This is a shortcut
     for `PORTUS_INIT_COMMAND=rails r /srv/Portus/bin/background.rb`.
+  * `PORTUS_RUN_FOREGROUND_AND_BACKGROUND`: you can set this environment to true in order to 
+    let puma and `bin/background.rb` execute together in the same container.
 
 You can also pass further environment variables to configure Portus as
 described [here](http://port.us.org/docs/Configuring-Portus.html#override-specific-configuration-options).

--- a/derived_images/portus/init
+++ b/derived_images/portus/init
@@ -65,6 +65,9 @@ if [ ! -z "$PORTUS_BACKGROUND" ]; then
     portusctl exec rails r /srv/Portus/bin/background.rb
 elif [ -z "$PORTUS_INIT_COMMAND" ]; then
     setup_database
+    if [ "$PORTUS_RUN_FOREGROUND_AND_BACKGROUND" = "true" ]; then
+        portusctl exec rails r /srv/Portus/bin/background.rb &
+    fi
     portusctl exec "pumactl -F /srv/Portus/config/puma.rb start"
 else
     portusctl exec "$PORTUS_INIT_COMMAND"


### PR DESCRIPTION
The purpose of this PR is to simplify the setup for production environments by allowing both ...
```
portusctl exec rails r /srv/Portus/bin/background.rb & 
portusctl exec "pumactl -F /srv/Portus/config/puma.rb start"
``` 
...in same container.

The functionality is controlled with environment variable `PORTUS_RUN_FOREGROUND_AND_BACKGROUND="true"`