### PR TITLE
Removing 'docker' references from sources

### DIFF
--- a/openSUSE-Leap-42.2/config.kiwi
+++ b/openSUSE-Leap-42.2/config.kiwi
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="openSUSE-Leap-42.2-docker-guest">
+<image schemaversion="6.5" name="openSUSE-Leap-42.2-container-guest">
   <description type="system">
     <author>SUSE Containers Team</author>
     <contact>containers@suse.com</contact>
-    <specification>openSUSE Leap 42.2 docker container</specification>
+    <specification>openSUSE Leap 42.2 container</specification>
   </description>
   <preferences>
     <type image="docker">

--- a/openSUSE-Leap-42.3/config.kiwi
+++ b/openSUSE-Leap-42.3/config.kiwi
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="openSUSE-Leap-42.3-docker-guest">
+<image schemaversion="6.5" name="openSUSE-Leap-42.3-container-guest">
   <description type="system">
     <author>SUSE Containers Team</author>
     <contact>containers@suse.com</contact>
-    <specification>openSUSE Leap 42.3 docker container</specification>
+    <specification>openSUSE Leap 42.3 container</specification>
   </description>
   <preferences>
     <type image="docker">

--- a/openSUSE-Tumbleweed/config.kiwi
+++ b/openSUSE-Tumbleweed/config.kiwi
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="openSUSE-Tumbleweed-docker-guest">
+<image schemaversion="6.5" name="openSUSE-Tumbleweed-container-guest">
   <description type="system">
     <author>SUSE Containers Team</author>
     <contact>containers@suse.com</contact>
-    <specification>openSUSE Tumbleweed docker container</specification>
+    <specification>openSUSE Tumbleweed container</specification>
   </description>
   <preferences>
     <type image="docker">


### PR DESCRIPTION
Remove _docker_ references in favor of _container_.