### PR TITLE
Follow the naming convention used in Kubic images

### DIFF
--- a/openSUSE-Leap-42.2/config.kiwi
+++ b/openSUSE-Leap-42.2/config.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="openSUSE-Leap-42.2-container-guest">
+<image schemaversion="6.5" name="openSUSE-Leap-42.2-container-image">
   <description type="system">
     <author>SUSE Containers Team</author>
     <contact>containers@suse.com</contact>

--- a/openSUSE-Leap-42.3/config.kiwi
+++ b/openSUSE-Leap-42.3/config.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="openSUSE-Leap-42.3-container-guest">
+<image schemaversion="6.5" name="openSUSE-Leap-42.3-container-image">
   <description type="system">
     <author>SUSE Containers Team</author>
     <contact>containers@suse.com</contact>

--- a/openSUSE-Tumbleweed/config.kiwi
+++ b/openSUSE-Tumbleweed/config.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="openSUSE-Tumbleweed-container-guest">
+<image schemaversion="6.5" name="openSUSE-Tumbleweed-container-image">
   <description type="system">
     <author>SUSE Containers Team</author>
     <contact>containers@suse.com</contact>


### PR DESCRIPTION
Follow the naming convention used in Kubic images