### PR TITLE
Move PORTUS_PUMA_HOST export to an ENV variable

### DIFF
--- a/derived_images/portus/Dockerfile
+++ b/derived_images/portus/Dockerfile
@@ -23,5 +23,7 @@ RUN chmod +x /init && \
     rm -rf /etc/pki/trust/anchors && \
     ln -sf /certificates /etc/pki/trust/anchors
 
+ENV PORTUS_PUMA_HOST="0.0.0.0:3000"
 EXPOSE 3000
+
 ENTRYPOINT ["/init"]

--- a/derived_images/portus/init
+++ b/derived_images/portus/init
@@ -82,7 +82,6 @@ done
 update-ca-certificates
 
 # Further settings
-export PORTUS_PUMA_HOST="0.0.0.0:3000"
 export RACK_ENV="production"
 export RAILS_ENV="production"
 export CCONFIG_PREFIX="PORTUS"


### PR DESCRIPTION
This commit moves PORTUS_PUMA_HOST variable set into the Dockerfile.
This way it can be easily configured at runtime.

Fixes #98