### PR TITLE
portus: use the proper leap reference

### DIFF
--- a/derived_images/portus/Dockerfile
+++ b/derived_images/portus/Dockerfile
@@ -1,4 +1,4 @@
-FROM opensuse/amd64:42.3
+FROM opensuse/leap:42.3
 MAINTAINER SUSE Containers Team <containers@suse.com>
 
 # Install the entrypoint of this image.


### PR DESCRIPTION
Thanks to @Vogtinator for the heads up!

See SUSE/Portus#1955

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>