### PR TITLE
portus: don't export empty secret environment variables or ignore empty values

### DIFF
--- a/derived_images/portus/init
+++ b/derived_images/portus/init
@@ -60,18 +60,19 @@ setup_database() {
 file_env() {
     local var="$1"
     local fileVar="${var}_FILE"
-    local def="${2:-}"
-    if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+    if [ -v "${var}" ] && [ -v "${fileVar}" ]; then
         echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
         exit 1
     fi
-    local val="$def"
-    if [ "${!var:-}" ]; then
+    if [ -v "${var}" ]; then
         val="${!var}"
-    elif [ "${!fileVar:-}" ]; then
+    elif [ -v "${fileVar}" ]; then
         val="$(< "${!fileVar}")"
     fi
-    export "$var"="$val"
+    # only export if a value was set
+    if [ -v "val" ]; then
+        export "$var"="$val"
+    fi
     unset "$fileVar"
 }
 

--- a/derived_images/portus/init
+++ b/derived_images/portus/init
@@ -64,13 +64,8 @@ file_env() {
         echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
         exit 1
     fi
-    if [ -v "${var}" ]; then
-        val="${!var}"
-    elif [ -v "${fileVar}" ]; then
+    if [ -v "${fileVar}" ]; then
         val="$(< "${!fileVar}")"
-    fi
-    # only export if a value was set
-    if [ -v "val" ]; then
         export "$var"="$val"
     fi
     unset "$fileVar"


### PR DESCRIPTION
Hi,

I had a problem with an empty password for ldap authentication. I set the password in the config-local.yml (templated) but got an empty ldap password.
Since the environment variables override the yaml config, empty values are only desired if the variable was set with an empty value ("-v" test), but not as default value. I changed file_env to get that behavior.

Regards
Daniel